### PR TITLE
Reduce the output of the capture CTE in powa_kcache_snapshot()

### DIFF
--- a/powa--3.2.0dev.sql
+++ b/powa--3.2.0dev.sql
@@ -1700,7 +1700,7 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     WITH capture AS (
-        SELECT *
+        SELECT k.*
         FROM pg_stat_kcache() k
         JOIN pg_roles r ON r.oid = k.userid
         WHERE NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')))


### PR DESCRIPTION
The capture CTE previously had the pg_roles columns in its output. We remove
them as those columns were not used.