### PR TITLE
Add capture functions

### DIFF
--- a/powa--3.1.2--3.2.0dev.sql
+++ b/powa--3.1.2--3.2.0dev.sql
@@ -1,6 +1,388 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 --\echo Use "ALTER EXTENSION powa" to load this file. \quit
 
+/* capture functions */
+/* part1: powa_functions table */
+ALTER TABLE powa_functions ADD COLUMN query_source text DEFAULT NULL;
+
+UPDATE powa_functions
+   SET query_source = 'get_statements_capture_data'
+ WHERE module = 'pg_stat_statements'
+   AND operation = 'snapshot';
+
+UPDATE powa_functions
+   SET query_source = 'get_user_functions_capture_data'
+ WHERE module = 'powa_stat_user_functions'
+   AND operation = 'snapshot';
+
+UPDATE powa_functions
+   SET query_source = 'get_all_relations_capture_data'
+ WHERE module = 'powa_stat_all_relations'
+   AND operation = 'snapshot';
+
+UPDATE powa_functions
+   SET query_source = 'get_qualstats_capture_data'
+ WHERE module = 'pg_qualstats'
+   AND operation = 'snapshot';
+
+UPDATE powa_functions
+   SET query_source = 'get_kcache_capture_data'
+ WHERE module = 'pg_stat_kcache'
+   AND operation = 'snapshot';
+
+/* capture functions */
+/* part2: capture and snapshot functions */
+CREATE OR REPLACE FUNCTION get_statements_capture_data() RETURNS SETOF pg_stat_statements AS $PROC$
+    SELECT pgss.*
+    FROM pg_stat_statements pgss
+    JOIN pg_roles r ON pgss.userid = r.oid
+    WHERE pgss.query !~* '^[[:space:]]*(DEALLOCATE|BEGIN|PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)'
+    AND NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')));
+$PROC$ LANGUAGE sql; /* end of get_statements_capture_data() */
+
+CREATE OR REPLACE FUNCTION powa_statements_snapshot() RETURNS void AS $PROC$
+DECLARE
+    result boolean;
+    v_funcname    text := 'powa_statements_snapshot';
+    v_rowcount    bigint;
+BEGIN
+    -- In this function, we capture statements, and also aggregate counters by database
+    -- so that the first screens of powa stay reactive even though there may be thousands
+    -- of different statements
+    PERFORM powa_log(format('running %I', v_funcname));
+
+    WITH capture AS(
+        SELECT * FROM get_statements_capture_data()
+    ),
+
+    missing_statements AS(
+        INSERT INTO powa_statements (queryid, dbid, userid, query)
+            SELECT queryid, dbid, userid, query
+            FROM capture c
+            WHERE NOT EXISTS (SELECT 1
+                              FROM powa_statements ps
+                              WHERE ps.queryid = c.queryid
+                              AND ps.dbid = c.dbid
+                              AND ps.userid = c.userid
+            )
+    ),
+
+    by_query AS (
+        INSERT INTO powa_statements_history_current
+            SELECT queryid, dbid, userid,
+            ROW(
+                now(), calls, total_time, rows, shared_blks_hit, shared_blks_read,
+                shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read,
+                local_blks_dirtied, local_blks_written, temp_blks_read, temp_blks_written,
+                blk_read_time, blk_write_time
+            )::powa_statements_history_record AS record
+            FROM capture
+    ),
+
+    by_database AS (
+        INSERT INTO powa_statements_history_current_db
+            SELECT dbid,
+            ROW(
+                now(), sum(calls), sum(total_time), sum(rows), sum(shared_blks_hit), sum(shared_blks_read),
+                sum(shared_blks_dirtied), sum(shared_blks_written), sum(local_blks_hit), sum(local_blks_read),
+                sum(local_blks_dirtied), sum(local_blks_written), sum(temp_blks_read), sum(temp_blks_written),
+                sum(blk_read_time), sum(blk_write_time)
+            )::powa_statements_history_record AS record
+            FROM capture
+            GROUP BY dbid
+    )
+
+    SELECT count(*) INTO v_rowcount
+    FROM capture;
+
+    perform powa_log(format('%I - rowcount: %s',
+            v_funcname, v_rowcount));
+
+    result := true; -- For now we don't care. What could we do on error except crash anyway?
+END;
+$PROC$ language plpgsql; /* end of powa_statements_snapshot */
+
+
+CREATE OR REPLACE FUNCTION get_user_functions_capture_data(
+    OUT dbid oid,
+    OUT funcid oid,
+    OUT calls bigint,
+    OUT total_time double precision,
+    OUT self_time double precision
+) RETURNS SETOF record AS $PROC$
+        SELECT oid, r.funcid, r.calls, r.total_time, r.self_time
+        FROM pg_database d, powa_stat_user_functions(oid) r
+$PROC$ LANGUAGE sql; /* end of get_user_functions_capture_data */
+
+CREATE OR REPLACE FUNCTION powa_user_functions_snapshot() RETURNS void AS $PROC$
+DECLARE
+    result boolean;
+    v_funcname    text := 'powa_user_functions_snapshot';
+    v_rowcount    bigint;
+BEGIN
+    PERFORM powa_log(format('running %I', v_funcname));
+
+    -- Insert cluster-wide user function statistics
+    WITH func AS (
+        SELECT * FROM get_user_functions_capture_data()
+    )
+    INSERT INTO powa_user_functions_history_current
+        SELECT dbid, funcid,
+        ROW(now(), calls, total_time,
+            self_time)::powa_user_functions_history_record AS record
+        FROM func;
+
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+
+    perform powa_log(format('%I - rowcount: %s',
+            v_funcname, v_rowcount));
+
+    result := true;
+END;
+$PROC$ language plpgsql; /* end of powa_user_functions_snapshot */
+
+CREATE OR REPLACE FUNCTION get_all_relations_capture_data(
+    OUT dbid oid,
+    OUT relid oid,
+    OUT numscan bigint,
+    OUT tup_returned bigint,
+    OUT tup_fetched bigint,
+    OUT n_tup_ins bigint,
+    OUT n_tup_upd bigint,
+    OUT n_tup_del bigint,
+    OUT n_tup_hot_upd bigint,
+    OUT n_liv_tup bigint,
+    OUT n_dead_tup bigint,
+    OUT n_mod_since_analyze bigint,
+    OUT blks_read bigint,
+    OUT blks_hit bigint,
+    OUT last_vacuum timestamp with time zone,
+    OUT vacuum_count bigint,
+    OUT last_autovacuum timestamp with time zone,
+    OUT autovacuum_count bigint,
+    OUT last_analyze timestamp with time zone,
+    OUT analyze_count bigint,
+    OUT last_autoanalyze timestamp with time zone,
+    OUT autoanalyze_count bigint)
+RETURNS SETOF record AS $PROC$
+       SELECT d.oid AS dbid, r.relid, r.numscan, r.tup_returned, r.tup_fetched,
+       r.n_tup_ins, r.n_tup_upd, r.n_tup_del, r.n_tup_hot_upd, r.n_liv_tup,
+       r.n_dead_tup, r.n_mod_since_analyze, r.blks_read, r.blks_hit, r.last_vacuum,
+       r.vacuum_count, r.last_autovacuum, r.autovacuum_count, r.last_analyze,
+       r.analyze_count, r.last_autoanalyze, r.autoanalyze_count
+       FROM pg_database d, powa_stat_all_rel(d.oid) as r
+$PROC$ LANGUAGE sql; /* end of get_all_relations_capture_data */
+
+CREATE OR REPLACE FUNCTION powa_all_relations_snapshot() RETURNS void AS $PROC$
+DECLARE
+    result boolean;
+    v_funcname    text := 'powa_all_relations_snapshot';
+    v_rowcount    bigint;
+BEGIN
+    PERFORM powa_log(format('running %I', v_funcname));
+
+    -- Insert cluster-wide relation statistics
+    WITH rel AS (
+        SELECT * FROM get_all_relations_capture_data()
+    )
+    INSERT INTO powa_all_relations_history_current
+        SELECT dbid, relid,
+        ROW(now(), numscan, tup_returned, tup_fetched,
+            n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd,
+            n_liv_tup, n_dead_tup, n_mod_since_analyze,
+            blks_read, blks_hit, last_vacuum, vacuum_count,
+            last_autovacuum, autovacuum_count, last_analyze,
+            analyze_count, last_autoanalyze,
+            autoanalyze_count)::powa_all_relations_history_record AS record
+        FROM rel;
+
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+
+    perform powa_log(format('%I - rowcount: %s',
+            v_funcname, v_rowcount));
+
+    result := true;
+END;
+$PROC$ language plpgsql; /* end of powa_all_relations_snapshot */
+
+
+CREATE OR REPLACE FUNCTION get_kcache_capture_data(OUT queryid bigint, OUT userid oid, OUT dbid oid,
+OUT reads bigint, OUT writes bigint, OUT user_time double precision, OUT system_time double precision)
+RETURNS SETOF record AS $PROC$
+BEGIN
+        RETURN QUERY
+        SELECT k.queryid, k.userid, k.dbid, k.reads, k.writes, k.user_time, k.system_time
+        FROM pg_stat_kcache() k
+        JOIN pg_roles r ON r.oid = k.userid
+        WHERE NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')));
+END;
+$PROC$ LANGUAGE plpgsql; /* end of get_kcache_capture_data() */
+
+CREATE OR REPLACE FUNCTION powa_kcache_snapshot() RETURNS void as $PROC$
+DECLARE
+  result bool;
+    v_funcname    text := 'powa_kcache_snapshot';
+    v_rowcount    bigint;
+BEGIN
+    PERFORM powa_log(format('running %I', v_funcname));
+
+    WITH capture AS (
+        SELECT * FROM get_kcache_capture_data()
+    ),
+
+    by_query AS (
+        INSERT INTO powa_kcache_metrics_current (queryid, dbid, userid, metrics)
+            SELECT queryid, dbid, userid, (now(), reads, writes, user_time, system_time)::kcache_type
+            FROM capture
+    ),
+
+    by_database AS (
+        INSERT INTO powa_kcache_metrics_current_db (dbid, metrics)
+            SELECT dbid, (now(), sum(reads), sum(writes), sum(user_time), sum(system_time))::kcache_type
+            FROM capture
+            GROUP BY dbid
+    )
+
+    SELECT COUNT(*) into v_rowcount
+    FROM capture;
+
+    perform powa_log(format('%I - rowcount: %s',
+            v_funcname, v_rowcount));
+
+    result := true;
+END
+$PROC$ language plpgsql; /* end of powa_kcache_snapshot */
+
+
+CREATE OR REPLACE FUNCTION get_qualstats_capture_data(
+    OUT uniquequalnodeid bigint,
+    OUT dbid oid,
+    OUT userid oid,
+    OUT qualnodeid bigint,
+    OUT occurences bigint,
+    OUT execution_count bigint,
+    OUT nbfiltered bigint,
+    OUT queryid bigint,
+    OUT constvalues varchar[],
+    OUT quals qual_type[]
+) RETURNS SETOF record AS $PROC$
+BEGIN
+    RETURN QUERY
+    SELECT pgqs.uniquequalnodeid, pgqs.dbid, pgqs.userid, pgqs.qualnodeid,
+           pgqs.occurences, pgqs.execution_count, pgqs.nbfiltered,
+           pgqs.queryid, pgqs.constvalues, pgqs.quals
+    FROM pg_qualstats_by_query pgqs
+    JOIN powa_statements s USING(queryid, dbid, userid)
+    JOIN pg_roles r ON s.userid = r.oid
+    AND NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')));
+END;
+$PROC$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION powa_qualstats_snapshot() RETURNS void as $PROC$
+DECLARE
+    result     bool;
+    v_funcname text := 'powa_qualstats_snapshot';
+    v_rowcount bigint;
+BEGIN
+  PERFORM powa_log(format('running %I', v_funcname));
+
+  WITH capture AS (
+    SELECT * FROM get_qualstats_capture_data()
+  ),
+  missing_quals AS (
+      INSERT INTO powa_qualstats_quals (qualid, queryid, dbid, userid, quals)
+        SELECT DISTINCT qs.qualnodeid, qs.queryid, qs.dbid, qs.userid, array_agg(DISTINCT q::qual_type)
+        FROM capture qs,
+        LATERAL (SELECT (unnest(quals)).*) as q
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM powa_qualstats_quals nh
+          WHERE nh.qualid = qs.qualnodeid AND nh.queryid = qs.queryid
+            AND nh.dbid = qs.dbid AND nh.userid = qs.userid
+        )
+        GROUP BY qualnodeid, queryid, dbid, userid
+      RETURNING *
+  ),
+  by_qual AS (
+      INSERT INTO powa_qualstats_quals_history_current (qualid, queryid, dbid, userid, ts, occurences, execution_count, nbfiltered)
+      SELECT qs.qualnodeid, qs.queryid, qs.dbid, qs.userid, now(), sum(occurences), sum(execution_count), sum(nbfiltered)
+        FROM capture as qs
+        GROUP BY qualnodeid, qs.queryid, qs.dbid, qs.userid
+      RETURNING *
+  ),
+  by_qual_with_const AS (
+      INSERT INTO powa_qualstats_constvalues_history_current(qualid, queryid, dbid, userid, ts, occurences, execution_count, nbfiltered, constvalues)
+      SELECT qualnodeid, qs.queryid, qs.dbid, qs.userid, now(), occurences, execution_count, nbfiltered, constvalues
+      FROM capture as qs
+  )
+  SELECT COUNT(*) into v_rowcount
+  FROM capture;
+
+  perform powa_log(format('%I - rowcount: %s',
+        v_funcname, v_rowcount));
+
+  result := true;
+  PERFORM pg_qualstats_reset();
+END
+$PROC$ language plpgsql; /* end of powa_qualstats_snapshot */
+
+/* capture functions */
+/* part3: register functions */
+CREATE OR REPLACE function public.powa_kcache_register() RETURNS bool AS
+$_$
+DECLARE
+    v_func_present bool;
+    v_ext_present bool;
+BEGIN
+    SELECT COUNT(*) = 1 INTO v_ext_present FROM pg_extension WHERE extname = 'pg_stat_kcache';
+
+    IF ( v_ext_present ) THEN
+        SELECT COUNT(*) > 0 INTO v_func_present FROM public.powa_functions WHERE module = 'pg_stat_kcache';
+        IF ( NOT v_func_present) THEN
+            PERFORM powa_log('registering pg_stat_kcache');
+
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_stat_kcache', 'snapshot',   'powa_kcache_snapshot',    'get_kcache_capture_data', false, true),
+                   ('pg_stat_kcache', 'aggregate',  'powa_kcache_aggregate',   NULL,                      false, true),
+                   ('pg_stat_kcache', 'unregister', 'powa_kcache_unregister',  NULL,                      false, true),
+                   ('pg_stat_kcache', 'purge',      'powa_kcache_purge',       NULL,                      false, true),
+                   ('pg_stat_kcache', 'reset',      'powa_kcache_reset',       NULL,                      false, true);
+        END IF;
+    END IF;
+
+    RETURN true;
+END;
+$_$
+language plpgsql; /* end of powa_kcache_register */
+
+CREATE OR REPLACE function public.powa_qualstats_register() RETURNS bool AS
+$_$
+DECLARE
+    v_func_present bool;
+    v_ext_present bool;
+BEGIN
+    SELECT COUNT(*) = 1 INTO v_ext_present FROM pg_extension WHERE extname = 'pg_qualstats';
+
+    IF ( v_ext_present) THEN
+        SELECT COUNT(*) > 0 INTO v_func_present FROM public.powa_functions WHERE function_name IN ('powa_qualstats_snapshot', 'powa_qualstats_aggregate', 'powa_qualstats_purge');
+        IF ( NOT v_func_present) THEN
+            PERFORM powa_log('registering pg_qualstats');
+
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_qualstats', 'snapshot',   'powa_qualstats_snapshot',    'get_qualstats_capture_data', false, true),
+                   ('pg_qualstats', 'aggregate',  'powa_qualstats_aggregate',   NULL,                         false, true),
+                   ('pg_qualstats', 'unregister', 'powa_qualstats_unregister',  NULL,                         false, true),
+                   ('pg_qualstats', 'purge',      'powa_qualstats_purge',       NULL,                         false, true),
+                   ('pg_qualstats', 'reset',      'powa_qualstats_reset',       NULL,                         false, true);
+        END IF;
+    END IF;
+
+    RETURN true;
+END;
+$_$
+language plpgsql; /* end of powa_qualstats_register */
+
+
 /* pg_wait_sampling integration - part 1 */
 CREATE TYPE public.wait_sampling_type AS (
     ts timestamptz,
@@ -136,6 +518,30 @@ BEGIN
 END;
 $_$; /* end of powa_check_created_extensions */
 
+CREATE OR REPLACE FUNCTION powa_track_settings_register() RETURNS bool AS $_$
+DECLARE
+    v_func_present bool;
+    v_ext_present bool;
+BEGIN
+    SELECT COUNT(*) = 1 INTO v_ext_present FROM pg_extension WHERE extname = 'pg_track_settings';
+
+    IF ( v_ext_present ) THEN
+        SELECT COUNT(*) > 0 INTO v_func_present FROM public.powa_functions WHERE module = 'pg_track_settings';
+        IF ( NOT v_func_present) THEN
+            PERFORM powa_log('registering pg_track_settings');
+
+            -- This extension handles its own storage, just its snapshot
+            -- function and an unregister function.
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_track_settings', 'snapshot',   'pg_track_settings_snapshot',     NULL, false, true),
+                   ('pg_track_settings', 'unregister', 'powa_track_settings_unregister', NULL, false, true);
+        END IF;
+    END IF;
+
+    RETURN true;
+END;
+$_$ language plpgsql; /* end of pg_track_settings_register */
+
 /* end pg_track_settings integration */
 
 /* pg_wait_sampling integration - part 2 */
@@ -156,12 +562,12 @@ BEGIN
         IF ( NOT v_func_present) THEN
             PERFORM powa_log('registering pg_wait_sampling');
 
-            INSERT INTO powa_functions (module, operation, function_name, added_manually, enabled)
-            VALUES ('pg_wait_sampling', 'snapshot',   'powa_wait_sampling_snapshot',   false, true),
-                   ('pg_wait_sampling', 'aggregate',  'powa_wait_sampling_aggregate',  false, true),
-                   ('pg_wait_sampling', 'unregister', 'powa_wait_sampling_unregister', false, true),
-                   ('pg_wait_sampling', 'purge',      'powa_wait_sampling_purge',      false, true),
-                   ('pg_wait_sampling', 'reset',      'powa_wait_sampling_reset',      false, true);
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_wait_sampling', 'snapshot',   'powa_wait_sampling_snapshot',   'get_wait_sampling_capture_data', false, true),
+                   ('pg_wait_sampling', 'aggregate',  'powa_wait_sampling_aggregate',  NULL,                             false, true),
+                   ('pg_wait_sampling', 'unregister', 'powa_wait_sampling_unregister', NULL,                             false, true),
+                   ('pg_wait_sampling', 'purge',      'powa_wait_sampling_purge',      NULL,                             false, true),
+                   ('pg_wait_sampling', 'reset',      'powa_wait_sampling_reset',      NULL,                             false, true);
         END IF;
     END IF;
 
@@ -183,6 +589,30 @@ END;
 $_$
 language plpgsql;
 
+CREATE OR REPLACE FUNCTION get_wait_sampling_capture_data(
+    OUT dbid oid,
+    OUT event_type text,
+    OUT event text,
+    OUT queryid bigint,
+    OUT count numeric)
+RETURNS SETOF record AS $PROC$
+BEGIN
+        RETURN QUERY
+        -- the various background processes report wait events but don't have
+        -- associated queryid.  Gather them all under a fake 0 dbid
+        SELECT COALESCE(pgss.dbid, 0) AS dbid, s.event_type, s.event, s.queryid,
+            sum(s.count) as count
+        FROM pg_wait_sampling_profile s
+        -- pg_wait_sampling doesn't offer a per (userid, dbid, queryid) view,
+        -- only per pid, but pid can be reused for different databases or users
+        -- so we cannot deduce db or user from it.  However, queryid should be
+        -- unique across differet databases, so we retrieve the dbid this way.
+        LEFT JOIN pg_stat_statements(false) pgss ON pgss.queryid = s.queryid
+        WHERE event_type IS NOT NULL AND event IS NOT NULL
+        GROUP BY pgss.dbid, s.event_type, s.event, s.queryid;
+END;
+$PROC$ LANGUAGE plpgsql;
+
 /*
  * powa_wait_sampling snapshot collection.
  */
@@ -195,18 +625,7 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     WITH capture AS (
-        -- the various background processes report wait events but don't have
-        -- associated queryid.  Gather them all under a fake 0 dbid
-        SELECT COALESCE(pgss.dbid, 0) AS dbid, s.event_type, s.event, s.queryid,
-            sum(s.count) as count
-        FROM pg_wait_sampling_profile s
-        -- pg_wait_sampling doesn't offer a per (userid, dbid, queryid) view,
-        -- only per pid, but pid can be reused for different databases or users
-        -- so we cannot deduce db or user from it.  However, queryid should be
-        -- unique across differet databases, so we retrieve the dbid this way.
-        LEFT JOIN pg_stat_statements(false) pgss ON pgss.queryid = s.queryid
-        WHERE event_type IS NOT NULL AND event IS NOT NULL
-        GROUP BY pgss.dbid, s.event_type, s.event, s.queryid
+        SELECT * FROM get_wait_sampling_capture_data()
     ),
 
     by_query AS (

--- a/powa--3.2.0dev.sql
+++ b/powa--3.2.0dev.sql
@@ -514,22 +514,23 @@ CREATE TABLE powa_functions (
     function_name text NOT NULL,
     added_manually boolean NOT NULL default true,
     enabled boolean NOT NULL default true,
+    query_source text default NULL,
     CHECK (operation IN ('snapshot','aggregate','purge','unregister','reset'))
 );
 
-INSERT INTO powa_functions (module, operation, function_name, added_manually, enabled) VALUES
-    ('pg_stat_statements', 'snapshot', 'powa_statements_snapshot', false, true),
-    ('powa_stat_user_functions', 'snapshot', 'powa_user_functions_snapshot', false, true),
-    ('powa_stat_all_relations', 'snapshot', 'powa_all_relations_snapshot', false, true),
-    ('pg_stat_statements', 'aggregate','powa_statements_aggregate', false, true),
-    ('powa_stat_user_functions', 'aggregate','powa_user_functions_aggregate', false, true),
-    ('powa_stat_all_relations', 'aggregate','powa_all_relations_aggregate', false, true),
-    ('pg_stat_statements', 'purge', 'powa_statements_purge', false, true),
-    ('powa_stat_user_functions', 'purge', 'powa_user_functions_purge', false, true),
-    ('powa_stat_all_relations', 'purge', 'powa_all_relations_purge', false, true),
-    ('pg_stat_statements', 'reset', 'powa_statements_reset', false, true),
-    ('powa_stat_user_functions', 'reset', 'powa_user_functions_reset', false, true),
-    ('powa_stat_all_relations', 'reset', 'powa_all_relations_reset', false, true);
+INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled) VALUES
+    ('pg_stat_statements', 'snapshot', 'powa_statements_snapshot', 'get_statements_capture_data', false, true),
+    ('powa_stat_user_functions', 'snapshot', 'powa_user_functions_snapshot', 'get_user_functions_capture_data', false, true),
+    ('powa_stat_all_relations', 'snapshot', 'powa_all_relations_snapshot', 'get_all_relations_capture_data', false, true),
+    ('pg_stat_statements', 'aggregate','powa_statements_aggregate', NULL, false, true),
+    ('powa_stat_user_functions', 'aggregate','powa_user_functions_aggregate', NULL, false, true),
+    ('powa_stat_all_relations', 'aggregate','powa_all_relations_aggregate', NULL, false, true),
+    ('pg_stat_statements', 'purge', 'powa_statements_purge', NULL, false, true),
+    ('powa_stat_user_functions', 'purge', 'powa_user_functions_purge', NULL, false, true),
+    ('powa_stat_all_relations', 'purge', 'powa_all_relations_purge', NULL, false, true),
+    ('pg_stat_statements', 'reset', 'powa_statements_reset', NULL, false, true),
+    ('powa_stat_user_functions', 'reset', 'powa_user_functions_reset', NULL, false, true),
+    ('powa_stat_all_relations', 'reset', 'powa_all_relations_reset', NULL, false, true);
 
 CREATE FUNCTION powa_log (msg text) RETURNS void
 LANGUAGE plpgsql
@@ -1217,10 +1218,17 @@ BEGIN
 END;
 $PROC$ LANGUAGE plpgsql; /* end of powa_take_snapshot */
 
+CREATE OR REPLACE FUNCTION get_statements_capture_data() RETURNS SETOF pg_stat_statements AS $PROC$
+    SELECT pgss.*
+    FROM pg_stat_statements pgss
+    JOIN pg_roles r ON pgss.userid = r.oid
+    WHERE pgss.query !~* '^[[:space:]]*(DEALLOCATE|BEGIN|PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)'
+    AND NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')));
+$PROC$ LANGUAGE sql; /* end of get_statements_capture_data() */
+
 CREATE OR REPLACE FUNCTION powa_statements_snapshot() RETURNS void AS $PROC$
 DECLARE
     result boolean;
-    ignore_regexp text :='^[[:space:]]*(DEALLOCATE|BEGIN|PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)';
     v_funcname    text := 'powa_statements_snapshot';
     v_rowcount    bigint;
 BEGIN
@@ -1230,11 +1238,7 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     WITH capture AS(
-        SELECT pgss.*
-        FROM pg_stat_statements pgss
-        JOIN pg_roles r ON pgss.userid = r.oid
-        WHERE pgss.query !~* ignore_regexp
-        AND NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')))
+        SELECT * FROM get_statements_capture_data()
     ),
 
     missing_statements AS(
@@ -1284,6 +1288,17 @@ BEGIN
 END;
 $PROC$ language plpgsql; /* end of powa_statements_snapshot */
 
+CREATE OR REPLACE FUNCTION get_user_functions_capture_data(
+    OUT dbid oid,
+    OUT funcid oid,
+    OUT calls bigint,
+    OUT total_time double precision,
+    OUT self_time double precision
+) RETURNS SETOF record AS $PROC$
+        SELECT oid, r.funcid, r.calls, r.total_time, r.self_time
+        FROM pg_database d, powa_stat_user_functions(oid) r
+$PROC$ LANGUAGE sql; /* end of get_user_functions_capture_data */
+
 CREATE OR REPLACE FUNCTION powa_user_functions_snapshot() RETURNS void AS $PROC$
 DECLARE
     result boolean;
@@ -1293,16 +1308,13 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     -- Insert cluster-wide user function statistics
-    WITH func(dbid, r) AS (
-        SELECT oid,
-            powa_stat_user_functions(oid)
-        FROM pg_database
+    WITH func AS (
+        SELECT * FROM get_user_functions_capture_data()
     )
     INSERT INTO powa_user_functions_history_current
-        SELECT dbid, (r).funcid,
-        ROW(now(), (r).calls,
-            (r).total_time,
-            (r).self_time)::powa_user_functions_history_record AS record
+        SELECT dbid, funcid,
+        ROW(now(), calls, total_time,
+            self_time)::powa_user_functions_history_record AS record
         FROM func;
 
     GET DIAGNOSTICS v_rowcount = ROW_COUNT;
@@ -1314,6 +1326,38 @@ BEGIN
 END;
 $PROC$ language plpgsql; /* end of powa_user_functions_snapshot */
 
+CREATE OR REPLACE FUNCTION get_all_relations_capture_data(
+    OUT dbid oid,
+    OUT relid oid,
+    OUT numscan bigint,
+    OUT tup_returned bigint,
+    OUT tup_fetched bigint,
+    OUT n_tup_ins bigint,
+    OUT n_tup_upd bigint,
+    OUT n_tup_del bigint,
+    OUT n_tup_hot_upd bigint,
+    OUT n_liv_tup bigint,
+    OUT n_dead_tup bigint,
+    OUT n_mod_since_analyze bigint,
+    OUT blks_read bigint,
+    OUT blks_hit bigint,
+    OUT last_vacuum timestamp with time zone,
+    OUT vacuum_count bigint,
+    OUT last_autovacuum timestamp with time zone,
+    OUT autovacuum_count bigint,
+    OUT last_analyze timestamp with time zone,
+    OUT analyze_count bigint,
+    OUT last_autoanalyze timestamp with time zone,
+    OUT autoanalyze_count bigint)
+RETURNS SETOF record AS $PROC$
+       SELECT d.oid AS dbid, r.relid, r.numscan, r.tup_returned, r.tup_fetched,
+       r.n_tup_ins, r.n_tup_upd, r.n_tup_del, r.n_tup_hot_upd, r.n_liv_tup,
+       r.n_dead_tup, r.n_mod_since_analyze, r.blks_read, r.blks_hit, r.last_vacuum,
+       r.vacuum_count, r.last_autovacuum, r.autovacuum_count, r.last_analyze,
+       r.analyze_count, r.last_autoanalyze, r.autoanalyze_count
+       FROM pg_database d, powa_stat_all_rel(d.oid) as r
+$PROC$ LANGUAGE sql; /* end of get_all_relations_capture_data */
+
 CREATE OR REPLACE FUNCTION powa_all_relations_snapshot() RETURNS void AS $PROC$
 DECLARE
     result boolean;
@@ -1323,20 +1367,18 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     -- Insert cluster-wide relation statistics
-    WITH rel(dbid, r) AS (
-        SELECT oid,
-            powa_stat_all_rel(oid)
-        FROM pg_database
+    WITH rel AS (
+        SELECT * FROM get_all_relations_capture_data()
     )
     INSERT INTO powa_all_relations_history_current
-        SELECT dbid, (r).relid,
-        ROW(now(),(r).numscan, (r).tup_returned, (r).tup_fetched,
-            (r).n_tup_ins, (r).n_tup_upd, (r).n_tup_del, (r).n_tup_hot_upd,
-            (r).n_liv_tup, (r).n_dead_tup, (r).n_mod_since_analyze,
-            (r).blks_read, (r).blks_hit, (r).last_vacuum, (r).vacuum_count,
-        (r).last_autovacuum, (r).autovacuum_count, (r).last_analyze,
-            (r).analyze_count, (r).last_autoanalyze,
-            (r).autoanalyze_count)::powa_all_relations_history_record AS record
+        SELECT dbid, relid,
+        ROW(now(), numscan, tup_returned, tup_fetched,
+            n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd,
+            n_liv_tup, n_dead_tup, n_mod_since_analyze,
+            blks_read, blks_hit, last_vacuum, vacuum_count,
+            last_autovacuum, autovacuum_count, last_analyze,
+            analyze_count, last_autoanalyze,
+            autoanalyze_count)::powa_all_relations_history_record AS record
         FROM rel;
 
     GET DIAGNOSTICS v_rowcount = ROW_COUNT;
@@ -1661,12 +1703,12 @@ BEGIN
         IF ( NOT v_func_present) THEN
             PERFORM powa_log('registering pg_stat_kcache');
 
-            INSERT INTO powa_functions (module, operation, function_name, added_manually, enabled)
-            VALUES ('pg_stat_kcache', 'snapshot',   'powa_kcache_snapshot',   false, true),
-                   ('pg_stat_kcache', 'aggregate',  'powa_kcache_aggregate',  false, true),
-                   ('pg_stat_kcache', 'unregister', 'powa_kcache_unregister', false, true),
-                   ('pg_stat_kcache', 'purge',      'powa_kcache_purge',      false, true),
-                   ('pg_stat_kcache', 'reset',      'powa_kcache_reset',      false, true);
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_stat_kcache', 'snapshot',   'powa_kcache_snapshot',    'get_kcache_capture_data', false, true),
+                   ('pg_stat_kcache', 'aggregate',  'powa_kcache_aggregate',   NULL,                      false, true),
+                   ('pg_stat_kcache', 'unregister', 'powa_kcache_unregister',  NULL,                      false, true),
+                   ('pg_stat_kcache', 'purge',      'powa_kcache_purge',       NULL,                      false, true),
+                   ('pg_stat_kcache', 'reset',      'powa_kcache_reset',       NULL,                      false, true);
         END IF;
     END IF;
 
@@ -1688,6 +1730,18 @@ END;
 $_$
 language plpgsql; /* end of powa_kcache_unregister */
 
+CREATE OR REPLACE FUNCTION get_kcache_capture_data(OUT queryid bigint, OUT userid oid, OUT dbid oid,
+OUT reads bigint, OUT writes bigint, OUT user_time double precision, OUT system_time double precision)
+RETURNS SETOF record AS $PROC$
+BEGIN
+        RETURN QUERY
+        SELECT k.queryid, k.userid, k.dbid, k.reads, k.writes, k.user_time, k.system_time
+        FROM pg_stat_kcache() k
+        JOIN pg_roles r ON r.oid = k.userid
+        WHERE NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')));
+END;
+$PROC$ LANGUAGE plpgsql; /* end of get_kcache_capture_data() */
+
 /*
  * powa_kcache snapshot collection.
  */
@@ -1700,10 +1754,7 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     WITH capture AS (
-        SELECT *
-        FROM pg_stat_kcache() k
-        JOIN pg_roles r ON r.oid = k.userid
-        WHERE NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')))
+        SELECT * FROM get_kcache_capture_data()
     ),
 
     by_query AS (
@@ -1853,12 +1904,12 @@ BEGIN
         IF ( NOT v_func_present) THEN
             PERFORM powa_log('registering pg_qualstats');
 
-            INSERT INTO powa_functions (module, operation, function_name, added_manually, enabled)
-            VALUES ('pg_qualstats', 'snapshot',   'powa_qualstats_snapshot',   false, true),
-                   ('pg_qualstats', 'aggregate',  'powa_qualstats_aggregate',  false, true),
-                   ('pg_qualstats', 'unregister', 'powa_qualstats_unregister', false, true),
-                   ('pg_qualstats', 'purge',      'powa_qualstats_purge',      false, true),
-                   ('pg_qualstats', 'reset',      'powa_qualstats_reset',      false, true);
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_qualstats', 'snapshot',   'powa_qualstats_snapshot',    'get_qualstats_capture_data', false, true),
+                   ('pg_qualstats', 'aggregate',  'powa_qualstats_aggregate',   NULL,                         false, true),
+                   ('pg_qualstats', 'unregister', 'powa_qualstats_unregister',  NULL,                         false, true),
+                   ('pg_qualstats', 'purge',      'powa_qualstats_purge',       NULL,                         false, true),
+                   ('pg_qualstats', 'reset',      'powa_qualstats_reset',       NULL,                         false, true);
         END IF;
     END IF;
 
@@ -1931,6 +1982,29 @@ LATERAL (
   ) s
 ) as me; /* end of powa_qualstats_aggregate_constvalues_current */
 
+CREATE OR REPLACE FUNCTION get_qualstats_capture_data(
+    OUT uniquequalnodeid bigint,
+    OUT dbid oid,
+    OUT userid oid,
+    OUT qualnodeid bigint,
+    OUT occurences bigint,
+    OUT execution_count bigint,
+    OUT nbfiltered bigint,
+    OUT queryid bigint,
+    OUT constvalues varchar[],
+    OUT quals qual_type[]
+) RETURNS SETOF record AS $PROC$
+BEGIN
+    RETURN QUERY
+    SELECT pgqs.uniquequalnodeid, pgqs.dbid, pgqs.userid, pgqs.qualnodeid,
+           pgqs.occurences, pgqs.execution_count, pgqs.nbfiltered,
+           pgqs.queryid, pgqs.constvalues, pgqs.quals
+    FROM pg_qualstats_by_query pgqs
+    JOIN powa_statements s USING(queryid, dbid, userid)
+    JOIN pg_roles r ON s.userid = r.oid
+    AND NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')));
+END;
+$PROC$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION powa_qualstats_snapshot() RETURNS void as $PROC$
 DECLARE
@@ -1941,11 +2015,7 @@ BEGIN
   PERFORM powa_log(format('running %I', v_funcname));
 
   WITH capture AS (
-    SELECT pgqs.*, s.query
-    FROM pg_qualstats_by_query pgqs
-    JOIN powa_statements s USING(queryid, dbid, userid)
-    JOIN pg_roles r ON s.userid = r.oid
-    AND NOT (r.rolname = ANY (string_to_array(current_setting('powa.ignored_users'),',')))
+    SELECT * FROM get_qualstats_capture_data()
   ),
   missing_quals AS (
       INSERT INTO powa_qualstats_quals (qualid, queryid, dbid, userid, quals)
@@ -2070,9 +2140,9 @@ BEGIN
 
             -- This extension handles its own storage, just its snapshot
             -- function and an unregister function.
-            INSERT INTO powa_functions (module, operation, function_name, added_manually, enabled)
-            VALUES ('pg_track_settings', 'snapshot',   'pg_track_settings_snapshot',   false, true),
-                   ('pg_track_settings', 'unregister', 'powa_track_settings_unregister',   false, true);
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_track_settings', 'snapshot',   'pg_track_settings_snapshot',     NULL, false, true),
+                   ('pg_track_settings', 'unregister', 'powa_track_settings_unregister', NULL, false, true);
         END IF;
     END IF;
 
@@ -2113,12 +2183,12 @@ BEGIN
         IF ( NOT v_func_present) THEN
             PERFORM powa_log('registering pg_wait_sampling');
 
-            INSERT INTO powa_functions (module, operation, function_name, added_manually, enabled)
-            VALUES ('pg_wait_sampling', 'snapshot',   'powa_wait_sampling_snapshot',   false, true),
-                   ('pg_wait_sampling', 'aggregate',  'powa_wait_sampling_aggregate',  false, true),
-                   ('pg_wait_sampling', 'unregister', 'powa_wait_sampling_unregister', false, true),
-                   ('pg_wait_sampling', 'purge',      'powa_wait_sampling_purge',      false, true),
-                   ('pg_wait_sampling', 'reset',      'powa_wait_sampling_reset',      false, true);
+            INSERT INTO powa_functions (module, operation, function_name, query_source, added_manually, enabled)
+            VALUES ('pg_wait_sampling', 'snapshot',   'powa_wait_sampling_snapshot',   'get_wait_sampling_capture_data', false, true),
+                   ('pg_wait_sampling', 'aggregate',  'powa_wait_sampling_aggregate',  NULL,                             false, true),
+                   ('pg_wait_sampling', 'unregister', 'powa_wait_sampling_unregister', NULL,                             false, true),
+                   ('pg_wait_sampling', 'purge',      'powa_wait_sampling_purge',      NULL,                             false, true),
+                   ('pg_wait_sampling', 'reset',      'powa_wait_sampling_reset',      NULL,                             false, true);
         END IF;
     END IF;
 
@@ -2140,6 +2210,24 @@ END;
 $_$
 language plpgsql;
 
+CREATE OR REPLACE FUNCTION get_wait_sampling_capture_data(OUT dbid oid, OUT event_type text, OUT event text, OUT queryid bigint, OUT count numeric) RETURNS SETOF RECORD AS $PROC$
+BEGIN
+        RETURN QUERY
+        -- the various background processes report wait events but don't have
+        -- associated queryid.  Gather them all under a fake 0 dbid
+        SELECT COALESCE(pgss.dbid, 0) AS dbid, s.event_type, s.event, s.queryid,
+            sum(s.count) as count
+        FROM pg_wait_sampling_profile s
+        -- pg_wait_sampling doesn't offer a per (userid, dbid, queryid) view,
+        -- only per pid, but pid can be reused for different databases or users
+        -- so we cannot deduce db or user from it.  However, queryid should be
+        -- unique across differet databases, so we retrieve the dbid this way.
+        LEFT JOIN pg_stat_statements(false) pgss ON pgss.queryid = s.queryid
+        WHERE event_type IS NOT NULL AND event IS NOT NULL
+        GROUP BY pgss.dbid, s.event_type, s.event, s.queryid;
+END;
+$PROC$ LANGUAGE plpgsql;
+
 /*
  * powa_wait_sampling snapshot collection.
  */
@@ -2152,18 +2240,7 @@ BEGIN
     PERFORM powa_log(format('running %I', v_funcname));
 
     WITH capture AS (
-        -- the various background processes report wait events but don't have
-        -- associated queryid.  Gather them all under a fake 0 dbid
-        SELECT COALESCE(pgss.dbid, 0) AS dbid, s.event_type, s.event, s.queryid,
-            sum(s.count) as count
-        FROM pg_wait_sampling_profile s
-        -- pg_wait_sampling doesn't offer a per (userid, dbid, queryid) view,
-        -- only per pid, but pid can be reused for different databases or users
-        -- so we cannot deduce db or user from it.  However, queryid should be
-        -- unique across differet databases, so we retrieve the dbid this way.
-        LEFT JOIN pg_stat_statements(false) pgss ON pgss.queryid = s.queryid
-        WHERE event_type IS NOT NULL AND event IS NOT NULL
-        GROUP BY pgss.dbid, s.event_type, s.event, s.queryid
+        SELECT * FROM get_wait_sampling_capture_data()
     ),
 
     by_query AS (


### PR DESCRIPTION
Add data capture functions to help implement a remote mode to PoWA.
    
All new functions are named after get_MODULE_capture_data() and give back
the data used in the corresponding snapshot functions.
    
The functions are also registered in a new column named query_source from
the powa_functions table. This way, a remote worker knows which function
to call to get all data.
    
Per idea from Julien Rouhaud.