### PR TITLE
 Allow PG_CONFIG value to be found on command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TESTS        = $(wildcard sql/*.sql)
 REGRESS      = $(patsubst sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 
 MODULES = powa
 


### PR DESCRIPTION
Use conditional variable assignment operator with PG_CONFIG to be able to override pg_config location on command-line, like in pg_qualstat.