### PR TITLE
Modify bgworker initialization to prevent showing garbage in pg_stat_activity 

### DIFF
--- a/powa.c
+++ b/powa.c
@@ -221,6 +221,8 @@ _PG_init(void)
 	/*
 	 * Register the worker processes
 	 */
+
+        memset(&worker, 0, sizeof(worker)); 
 	worker.bgw_flags =
 		BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
 	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;		/* Must write to the

--- a/powa.c
+++ b/powa.c
@@ -221,8 +221,7 @@ _PG_init(void)
 	/*
 	 * Register the worker processes
 	 */
-
-        memset(&worker, 0, sizeof(worker)); 
+	memset(&worker, 0, sizeof(worker)); 
 	worker.bgw_flags =
 		BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
 	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;		/* Must write to the


### PR DESCRIPTION
Hello, team

From postgres 11 there is opportunity to specify background worker type by filling bgw_type in BackgroundWorker structure. If bgw_type is empty string then we copy bgw_name into bgw_type. But in _PG_init BackgroundWorker structure is not fully initialized, so it can be garbage in bgw_type field. And this garbage will be shown in backend_type column in pg_stat_activity. We can bypass it by setting bgw_type. We can also use memset to zero BackgroundWorker structure. Then bgw_name value will be copied into bgw_type