### PR TITLE
Fix typos in SQL comments

### DIFF
--- a/powa--3.1.0.sql
+++ b/powa--3.1.0.sql
@@ -686,7 +686,7 @@ CREATE TYPE powa_qualstats_history_item AS (
   nbfiltered bigint
 );
 
-/* pg_stat_qualstats operator support */
+/* pg_qualstats operator support */
 CREATE TYPE powa_qualstats_history_diff AS (
     intvl interval,
     occurences bigint,
@@ -754,7 +754,7 @@ CREATE OPERATOR / (
     LEFTARG = powa_qualstats_history_item,
     RIGHTARG = powa_qualstats_history_item
 );
-/* end of pg_stat_qualstats operator support */
+/* end of pg_qualstats operator support */
 
 CREATE TABLE public.powa_qualstats_quals (
     qualid bigint,

--- a/powa--3.1.1.sql
+++ b/powa--3.1.1.sql
@@ -686,7 +686,7 @@ CREATE TYPE powa_qualstats_history_item AS (
   nbfiltered bigint
 );
 
-/* pg_stat_qualstats operator support */
+/* pg_qualstats operator support */
 CREATE TYPE powa_qualstats_history_diff AS (
     intvl interval,
     occurences bigint,
@@ -754,7 +754,7 @@ CREATE OPERATOR / (
     LEFTARG = powa_qualstats_history_item,
     RIGHTARG = powa_qualstats_history_item
 );
-/* end of pg_stat_qualstats operator support */
+/* end of pg_qualstats operator support */
 
 CREATE TABLE public.powa_qualstats_quals (
     qualid bigint,

--- a/powa--3.1.2.sql
+++ b/powa--3.1.2.sql
@@ -686,7 +686,7 @@ CREATE TYPE powa_qualstats_history_item AS (
   nbfiltered bigint
 );
 
-/* pg_stat_qualstats operator support */
+/* pg_qualstats operator support */
 CREATE TYPE powa_qualstats_history_diff AS (
     intvl interval,
     occurences bigint,
@@ -754,7 +754,7 @@ CREATE OPERATOR / (
     LEFTARG = powa_qualstats_history_item,
     RIGHTARG = powa_qualstats_history_item
 );
-/* end of pg_stat_qualstats operator support */
+/* end of pg_qualstats operator support */
 
 CREATE TABLE public.powa_qualstats_quals (
     qualid bigint,

--- a/powa--3.2.0.sql
+++ b/powa--3.2.0.sql
@@ -686,7 +686,7 @@ CREATE TYPE powa_qualstats_history_item AS (
   nbfiltered bigint
 );
 
-/* pg_stat_qualstats operator support */
+/* pg_qualstats operator support */
 CREATE TYPE powa_qualstats_history_diff AS (
     intvl interval,
     occurences bigint,
@@ -754,7 +754,7 @@ CREATE OPERATOR / (
     LEFTARG = powa_qualstats_history_item,
     RIGHTARG = powa_qualstats_history_item
 );
-/* end of pg_stat_qualstats operator support */
+/* end of pg_qualstats operator support */
 
 CREATE TABLE public.powa_qualstats_quals (
     qualid bigint,

--- a/powa--3.2.1dev.sql
+++ b/powa--3.2.1dev.sql
@@ -687,7 +687,7 @@ CREATE TYPE powa_qualstats_history_item AS (
   nbfiltered bigint
 );
 
-/* pg_stat_qualstats operator support */
+/* pg_qualstats operator support */
 CREATE TYPE powa_qualstats_history_diff AS (
     intvl interval,
     occurences bigint,
@@ -755,7 +755,7 @@ CREATE OPERATOR / (
     LEFTARG = powa_qualstats_history_item,
     RIGHTARG = powa_qualstats_history_item
 );
-/* end of pg_stat_qualstats operator support */
+/* end of pg_qualstats operator support */
 
 CREATE TABLE public.powa_qualstats_quals (
     qualid bigint,

--- a/powa--4.0.0beta1.sql
+++ b/powa--4.0.0beta1.sql
@@ -1330,7 +1330,7 @@ CREATE UNLOGGED TABLE public.powa_qualstats_src_tmp(
     quals qual_type[] NOT NULL
 );
 
-/* pg_stat_qualstats operator support */
+/* pg_qualstats operator support */
 CREATE TYPE powa_qualstats_history_diff AS (
     intvl interval,
     occurences bigint,
@@ -1398,7 +1398,7 @@ CREATE OPERATOR / (
     LEFTARG = powa_qualstats_history_item,
     RIGHTARG = powa_qualstats_history_item
 );
-/* end of pg_stat_qualstats operator support */
+/* end of pg_qualstats operator support */
 
 CREATE TABLE public.powa_qualstats_quals (
     srvid integer NOT NULL,


### PR DESCRIPTION
This fixes a copy/pasted silly typo in SQL comments. It doesn't matter in reality, but it keeps throwing my searches of code off :)

As it it's in comments only, there is no functionality change.