### PR TITLE
Fix pg11- pg_stat_activity support

### DIFF
--- a/powa--5.0.0dev.sql
+++ b/powa--5.0.0dev.sql
@@ -4835,7 +4835,7 @@ BEGIN
             0::bigint AS blks_zeroed, 0::bigint AS blks_hit,
             0::bigint AS blks_read, 0::bigint AS blks_written,
             0::bigint AS blks_exists,
-            0::bigint AS flushes, 0::bigint as truncates
+            0::bigint AS flushes, 0::bigint as truncates,
             NULL::timestamp with time zone AS stats_reset
             WHERE false;
         END IF;

--- a/powa--5.0.0dev.sql
+++ b/powa--5.0.0dev.sql
@@ -4585,10 +4585,11 @@ BEGIN
             s.tup_inserted, s.tup_updated, s.tup_deleted, s.conflicts,
             s.temp_files, s.temp_bytes, s.deadlocks, s.checksum_failures,
             s.checksum_last_failure, s.blk_read_time, s.blk_write_time,
-            NULL AS session_time, NULL AS active_time,
-            NULL AS idle_in_transaction_time,
-            NULL AS sessions, NULL AS sessions_abandoned,
-            NULL AS sessions_fatal, NULL AS sessions_killed,
+            NULL::double precision AS session_time,
+            NULL::double precision AS active_time,
+            NULL::double precision AS idle_in_transaction_time,
+            NULL::bigint AS sessions, NULL::bigint AS sessions_abandoned,
+            NULL::bigint AS sessions_fatal, NULL::bigint AS sessions_killed,
             s.stats_reset
             FROM pg_catalog.pg_stat_database AS s;
         ELSE
@@ -4597,11 +4598,13 @@ BEGIN
             s.blks_read, s.blks_hit, s.tup_returned, s.tup_fetched,
             s.tup_inserted, s.tup_updated, s.tup_deleted, s.conflicts,
             s.temp_files, s.temp_bytes, s.deadlocks, 0 AS checksum_failures,
-            NULL AS checksum_last_failure, s.blk_read_time, s.blk_write_time,
-            NULL AS session_time, NULL AS active_time,
-            NULL AS idle_in_transaction_time,
-            NULL AS sessions, NULL AS sessions_abandoned,
-            NULL AS sessions_fatal, NULL AS sessions_killed,
+            NULL::double precision AS checksum_last_failure,
+            s.blk_read_time, s.blk_write_time,
+            NULL::double precision AS session_time,
+            NULL::double precision AS active_time,
+            NULL::double precision AS idle_in_transaction_time,
+            NULL::bigint AS sessions, NULL::bigint AS sessions_abandoned,
+            NULL::bigint AS sessions_fatal, NULL::bigint AS sessions_killed,
             s.stats_reset
             FROM pg_catalog.pg_stat_database AS s;
         END IF;

--- a/powa--5.0.0dev.sql
+++ b/powa--5.0.0dev.sql
@@ -4368,26 +4368,27 @@ BEGIN
                 s.application_name, s.client_addr, s.backend_start,
                 s.xact_start,
                 s.query_start, s.state_change, s.state, s.backend_xid,
-                s.backend_xmin, NULL AS query_id, s.backend_type
+                s.backend_xmin, NULL::bigint AS query_id, s.backend_type
             FROM pg_catalog.pg_stat_activity AS s;
         -- backend_type added in pg10+
         ELSIF current_setting('server_version_num')::int >= 100000 THEN
             RETURN QUERY SELECT now(),
                 txid,
-                s.datid, s.pid, NULL AS leader_pid, s.usesysid,
+                s.datid, s.pid, NULL::integer AS leader_pid, s.usesysid,
                 s.application_name, s.client_addr, s.backend_start,
                 s.xact_start,
                 s.query_start, s.state_change, s.state, s.backend_xid,
-                s.backend_xmin, NULL AS query_id, s.backend_type
+                s.backend_xmin, NULL::bigint AS query_id, s.backend_type
             FROM pg_catalog.pg_stat_activity AS s;
         ELSE
             RETURN QUERY SELECT now(),
                 txid,
-                s.datid, s.pid, NULL AS leader_pid, s.usesysid,
+                s.datid, s.pid, NULL::integer AS leader_pid, s.usesysid,
                 s.application_name, s.client_addr, s.backend_start,
                 s.xact_start,
                 s.query_start, s.state_change, s.state, s.backend_xid,
-                s.backend_xmin, NULL AS query_id, NULL AS backend_type
+                s.backend_xmin, NULL::bigint AS query_id,
+                NULL::text AS backend_type
             FROM pg_catalog.pg_stat_activity AS s;
         END IF;
     ELSE

--- a/powa--5.0.0dev.sql
+++ b/powa--5.0.0dev.sql
@@ -4265,8 +4265,10 @@ BEGIN
                 v_txid, v_current_lsn,
                 s.active,
                 s.active_pid, s.xmin AS slot_xmin, s.catalog_xmin,
-                s.restart_lsn, s.confirmed_flush_lsn, NULL as wal_status,
-                NULL as safe_wal_size, false AS two_phase, false AS conflicting
+                s.restart_lsn, s.confirmed_flush_lsn,
+                NULL::text as wal_status,
+                NULL::bigint as safe_wal_size,
+                false AS two_phase, false AS conflicting
             FROM (SELECT now() AS now) n
             LEFT JOIN pg_catalog.pg_replication_slots AS s ON true;
         -- confirmed_flush_lsn added in pg9.6
@@ -4277,8 +4279,10 @@ BEGIN
                 v_txid, v_current_lsn,
                 s.active,
                 s.active_pid, s.xmin AS slot_xmin, s.catalog_xmin,
-                s.restart_lsn, s.confirmed_flush_lsn, NULL as wal_status,
-                NULL as safe_wal_size, false AS two_phase, false AS conflicting
+                s.restart_lsn, s.confirmed_flush_lsn,
+                NULL::text as wal_status,
+                NULL::bigint as safe_wal_size,
+                false AS two_phase, false AS conflicting
             FROM (SELECT now() AS now) n
             LEFT JOIN pg_catalog.pg_replication_slots AS s ON true;
         -- active_pid added in pg9.5
@@ -4289,8 +4293,10 @@ BEGIN
                 v_txid, v_current_lsn,
                 s.active,
                 s.active_pid, s.xmin AS slot_xmin, s.catalog_xmin,
-                s.restart_lsn, NULL AS confirmed_flush_lsn, NULL as wal_status,
-                NULL as safe_wal_size, false AS two_phase, false AS conflicting
+                s.restart_lsn, NULL::pg_lsn AS confirmed_flush_lsn,
+                NULL::text as wal_status,
+                NULL::bigint as safe_wal_size,
+                false AS two_phase, false AS conflicting
             FROM (SELECT now() AS now) n
             LEFT JOIN pg_catalog.pg_replication_slots AS s ON true;
         ELSE
@@ -4299,9 +4305,11 @@ BEGIN
                 s.slot_type, s.datoid, false AS temporary,
                 v_txid, v_current_lsn,
                 s.active,
-                NULL AS active_pid, s.xmin AS slot_xmin, s.catalog_xmin,
-                s.restart_lsn, NULL AS confirmed_flush_lsn, NULL as wal_status,
-                NULL as safe_wal_size, false AS two_phase, false AS conflicting
+                NULL::int AS active_pid, s.xmin AS slot_xmin, s.catalog_xmin,
+                s.restart_lsn, NULL::pg_lsn AS confirmed_flush_lsn,
+                NULL::text as wal_status,
+                NULL::bigint as safe_wal_size,
+                false AS two_phase, false AS conflicting
             FROM (SELECT now() AS now) n
             LEFT JOIN pg_catalog.pg_replication_slots AS s ON true;
         END IF;


### PR DESCRIPTION
The query_id field needs to be explicitly casted when NULL is used as a fallback value.