### PR TITLE
Fix pg_dump error on powa_module_config

### DIFF
--- a/powa--5.0.0--5.0.1dev.sql
+++ b/powa--5.0.0--5.0.1dev.sql
@@ -1,2 +1,54 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION powa" to load this file. \quit
+
+ALTER TABLE @extschema@.powa_module_config DROP COLUMN added_manually;
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_config','');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_functions','');
+
+CREATE FUNCTION @extschema@.powa_activate_module(_srvid int, _module text) RETURNS boolean
+AS $_$
+DECLARE
+    v_res bool;
+BEGIN
+    IF (_srvid IS NULL) THEN
+        RAISE EXCEPTION 'powa_activate_module: no server id provided';
+    END IF;
+
+    IF (_module IS NULL) THEN
+        RAISE EXCEPTION 'powa_activate_module: no module provided';
+    END IF;
+
+    -- Check that the module is known.
+    SELECT COUNT(*) = 1 INTO v_res
+    FROM @extschema@.powa_modules
+    WHERE module = _module;
+
+    IF (NOT v_res) THEN
+        RAISE EXCEPTION 'Module "%" is not known', _module;
+    END IF;
+
+    -- The record may already be present, but the enabled flag could be off.
+    -- If so simply enable it.  Otherwise, add the needed record.
+    SELECT COUNT(*) > 0 INTO v_res
+    FROM @extschema@.powa_module_config
+    WHERE module = _module
+    AND srvid = _srvid;
+
+    IF (v_res) THEN
+        UPDATE @extschema@.powa_module_config
+        SET enabled = true
+        WHERE enabled = false
+        AND srvid = _srvid
+        AND module = _module;
+    ELSE
+        INSERT INTO @extschema@.powa_module_config
+            (srvid, module)
+        VALUES
+            (_srvid, _module);
+    END IF;
+
+    RETURN true;
+END;
+$_$ LANGUAGE plpgsql
+SET search_path = pg_catalog; /* end of powa_activate_module */

--- a/powa--5.0.1dev.sql
+++ b/powa--5.0.1dev.sql
@@ -225,7 +225,6 @@ CREATE TABLE @extschema@.powa_module_config (
     srvid integer NOT NULL,
     module text NOT NULL,
     enabled bool NOT NULL default true,
-    added_manually boolean NOT NULL default true,
     PRIMARY KEY (srvid, module),
     FOREIGN KEY (srvid) REFERENCES @extschema@.powa_servers(id)
       MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE,
@@ -233,9 +232,9 @@ CREATE TABLE @extschema@.powa_module_config (
       MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-INSERT INTO @extschema@.powa_module_config (srvid, module, added_manually) VALUES
-    (0, 'pg_database', false),
-    (0, 'pg_role', false);
+INSERT INTO @extschema@.powa_module_config (srvid, module) VALUES
+    (0, 'pg_database'),
+    (0, 'pg_role');
 
 CREATE TABLE @extschema@.powa_module_functions (
     module text NOT NULL,
@@ -1255,7 +1254,7 @@ BEGIN
 
     -- declare the module and its configuration
     INSERT INTO @extschema@.powa_modules VALUES (_pg_module, _min_version);
-    INSERT INTO @extschema@.powa_module_config VALUES (0, _pg_module, false);
+    INSERT INTO @extschema@.powa_module_config VALUES (0, _pg_module);
     INSERT INTO @extschema@.powa_module_functions VALUES
         (_pg_module, 'snapshot',  v_module || '_snapshot',  v_module || '_src'),
         (_pg_module, 'aggregate', v_module || '_aggregate', NULL),
@@ -2296,9 +2295,9 @@ BEGIN
         AND module = _module;
     ELSE
         INSERT INTO @extschema@.powa_module_config
-            (srvid, module, added_manually)
+            (srvid, module)
         VALUES
-            (_srvid, _module, (_srvid != 0));
+            (_srvid, _module);
     END IF;
 
     RETURN true;
@@ -3166,8 +3165,8 @@ SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_all_tables_history_
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_extensions','WHERE added_manually');
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_extension_functions','WHERE added_manually');
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_extension_config','WHERE added_manually');
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_functions','WHERE added_manually');
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_config','WHERE added_manually');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_functions','');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_config','');
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_catalog_databases','');
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_catalog_roles','');
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_catalog_class','');


### PR DESCRIPTION
powa_modules are used for cluster-wide pg_stat datasources and do not support custom datasources.

powa_modules and powa_module_functions got it right and don't have the usual "added_manually" column used to distinguish custom rows, but powa_module_functions had a wrong reference to this column.  Also, powa_module_config was incorrectly created with an added_manually column, and dump was configure using it but the extension install script was incorrectly marking some of the init-time data to be custom.

To fix, get rid of any mention of that column in either the table structure of the dump config.

Thanks to github user guruguruguru for the report.