### PR TITLE
Fix powa_activate_module command in 5.0.0--5.0.1 script

### DIFF
--- a/powa--5.0.0--5.0.1dev.sql
+++ b/powa--5.0.0--5.0.1dev.sql
@@ -6,7 +6,7 @@ ALTER TABLE @extschema@.powa_module_config DROP COLUMN added_manually;
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_config','');
 SELECT pg_catalog.pg_extension_config_dump('@extschema@.powa_module_functions','');
 
-CREATE FUNCTION @extschema@.powa_activate_module(_srvid int, _module text) RETURNS boolean
+CREATE OR REPLACE FUNCTION @extschema@.powa_activate_module(_srvid int, _module text) RETURNS boolean
 AS $_$
 DECLARE
     v_res bool;


### PR DESCRIPTION
The function already exists so there should be an "OR REPLACE" clause.