### PR TITLE
Fix pg_track_settings in powa_delete_and_purge_server()

### DIFF
--- a/powa--5.0.0--5.0.1dev.sql
+++ b/powa--5.0.0--5.0.1dev.sql
@@ -52,3 +52,48 @@ BEGIN
 END;
 $_$ LANGUAGE plpgsql
 SET search_path = pg_catalog; /* end of powa_activate_module */
+
+CREATE OR REPLACE FUNCTION @extschema@.powa_delete_and_purge_server(_srvid integer) RETURNS boolean
+AS $_$
+DECLARE
+    v_rowcount bigint;
+    v_extnsp text;
+BEGIN
+    IF (_srvid = 0) THEN
+        RAISE EXCEPTION 'Local server cannot be deleted';
+    END IF;
+
+    DELETE FROM @extschema@.powa_servers WHERE id = _srvid;
+
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+
+    -- pg_track_settings is an autonomous extension, so it doesn't have a FK to
+    -- powa_servers.  It therefore needs to be processed manually
+    SELECT COUNT(*), nspname
+        FROM pg_extension e
+        LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
+        WHERE extname = 'pg_track_settings'
+        GROUP BY nspname
+        INTO v_rowcount, v_extnsp;
+    IF (v_rowcount = 1) THEN
+        EXECUTE format('DELETE FROM %I.pg_track_settings_list WHERE srvid = %s',
+            v_extnsp,
+            _srvid);
+        EXECUTE format('DELETE FROM %I.pg_track_settings_history WHERE srvid = %s',
+            v_extnsp,
+            _srvid);
+        EXECUTE format('DELETE FROM %I.pg_track_db_role_settings_list WHERE srvid = %s',
+            v_extnsp,
+            _srvid);
+        EXECUTE format('DELETE FROM %I.pg_track_db_role_settings_history WHERE srvid = %s',
+            v_extnsp,
+            _srvid);
+        EXECUTE format('DELETE FROM %I.pg_reboot WHERE srvid = %s',
+            v_extnsp,
+            _srvid);
+    END IF;
+
+    RETURN v_rowcount = 1;
+END;
+$_$ LANGUAGE plpgsql
+SET search_path = pg_catalog; /* powa_delete_and_purge_server */


### PR DESCRIPTION
That function wasn't modified to properly handle schema qualification for the pg_track_settings-specific queries.

Thanks to Thomas Reiss for the report.