### PR TITLE
Smooth out the coalesces and purges

### DIFF
--- a/powa--5.0.2.sql
+++ b/powa--5.0.2.sql
@@ -3441,8 +3441,8 @@ BEGIN
       END;
     END LOOP;
 
-    -- Coalesce datas if needed
-    IF ( ((purge_seq + _srvid ) % v_coalesce ) = 0 )
+    -- Coalesce datas if needed. The _srvid % 20 is there to avoid having all coalesces run at once
+    IF ( ((purge_seq + (_srvid % 20) ) % v_coalesce ) = 0 )
     THEN
       PERFORM @extschema@.powa_log(
         format('coalesce needed, srvid: %s - seq: %s - coalesce seq: %s',
@@ -3499,7 +3499,8 @@ BEGIN
     END IF;
 
     -- We also purge, at the pass after the coalesce
-    IF ( ((purge_seq + _srvid) % v_coalesce) = 1 )
+    -- The _srvid % 20 is there to avoid having all purges run at once
+    IF ( ((purge_seq + (_srvid % 20)) % v_coalesce) = 1 )
     THEN
       PERFORM @extschema@.powa_log(
         format('purge needed, srvid: %s - seq: %s coalesce seq: %s',

--- a/powa--5.0.2.sql
+++ b/powa--5.0.2.sql
@@ -3442,7 +3442,7 @@ BEGIN
     END LOOP;
 
     -- Coalesce datas if needed
-    IF ( (purge_seq % v_coalesce ) = 0 )
+    IF ( ((purge_seq + _srvid ) % v_coalesce ) = 0 )
     THEN
       PERFORM @extschema@.powa_log(
         format('coalesce needed, srvid: %s - seq: %s - coalesce seq: %s',
@@ -3499,7 +3499,7 @@ BEGIN
     END IF;
 
     -- We also purge, at the pass after the coalesce
-    IF ( (purge_seq % v_coalesce) = 1 )
+    IF ( ((purge_seq + _srvid) % v_coalesce) = 1 )
     THEN
       PERFORM @extschema@.powa_log(
         format('purge needed, srvid: %s - seq: %s coalesce seq: %s',


### PR DESCRIPTION
This is to work around the use case of someone importing a bunch of servers at the same time: when this occurs, all those servers are going to coalesce at about the same time, then purge at about the same time, which may saturate IOs

By adding the srvid to the modulo, servers created in sequence will end up offset by 1 for their coalesces/purges. Their first ever coalesced records will be smaller, but I don't see how it would end up being a problem