### PR TITLE
Fix typo in collection of aggregate of functions per DB

### DIFF
--- a/powa--5.0.2.sql
+++ b/powa--5.0.2.sql
@@ -5772,7 +5772,7 @@ BEGIN
                 min((record).self_time))::@extschema@.powa_user_functions_history_record,
             ROW(max((record).ts), max((record).calls),max((record).total_time),
                 max((record).self_time))::@extschema@.powa_user_functions_history_record
-        FROM @extschema@.powa_user_functions_history_current
+        FROM @extschema@.powa_user_functions_history_current_db
         WHERE srvid = _srvid
         GROUP BY srvid, dbid;
 


### PR DESCRIPTION
powa_user_functions_history_db is empty right now, I think because of this bug

I'm testing it right now on my environment

What I don't understand is why I don't see any error in the logs