### PR TITLE
Fix powa_delete_and_purge_server to also purge *_src_tmp tables

### DIFF
--- a/expected/02_remote_api.out
+++ b/expected/02_remote_api.out
@@ -239,7 +239,7 @@ BEGIN;
 SELECT * from "PoWA".powa_delete_and_purge_server(1);
  powa_delete_and_purge_server 
 ------------------------------
- 
+ t
 (1 row)
 
 -- and rollback it as we later test the content of tables with a registered

--- a/powa--5.0.2.sql
+++ b/powa--5.0.2.sql
@@ -2764,7 +2764,9 @@ SET search_path = pg_catalog; /* powa_deactivate_server */
 CREATE FUNCTION @extschema@.powa_delete_and_purge_server(_srvid integer) RETURNS boolean
 AS $_$
 DECLARE
+    v_deleted bool;
     v_rowcount bigint;
+    v_src_tmp text;
     v_extnsp text;
 BEGIN
     IF (_srvid = 0) THEN
@@ -2773,7 +2775,39 @@ BEGIN
 
     DELETE FROM @extschema@.powa_servers WHERE id = _srvid;
 
+    -- Remember if we removed a remote server
     GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+    v_deleted := (v_rowcount = 1);
+
+    -- The powa_db_modules stores fully qualified (and quoted) src table name,
+    -- so we have to return the same everywhere to keep the code consistent.
+    --
+    -- Note also that there is no guarantee that all the source tables in the
+    -- powa_extension_functions exist.  At the very least the pg_track_settings
+    -- source table could be missing if that extension is not enabled on any of
+    -- the remove or even local servers, so we have to double check for their
+    -- existence first.
+    FOR v_src_tmp IN
+        SELECT '@extschema@' || '.' || quote_ident(tmp_table)
+        FROM @extschema@.powa_catalogs
+        UNION ALL
+        SELECT tmp_table
+        FROM @extschema@.powa_db_modules
+        UNION ALL
+        SELECT '@extschema@' || '.' || quote_ident(query_source || '_tmp')
+        FROM @extschema@.powa_extension_functions pef
+        JOIN pg_catalog.pg_class c ON c.relname = (query_source || '_tmp')
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            AND quote_ident(nspname) = '@extschema@'
+        WHERE query_source IS NOT NULL
+        UNION ALL
+        SELECT '@extschema@' || '.' || quote_ident(query_source || '_tmp')
+        FROM @extschema@.powa_module_functions
+        WHERE query_source IS NOT NULL
+    LOOP
+        EXECUTE format('DELETE FROM %s WHERE srvid = %s',
+            v_src_tmp, _srvid);
+    END LOOP;
 
     -- pg_track_settings is an autonomous extension, so it doesn't have a FK to
     -- powa_servers.  It therefore needs to be processed manually
@@ -2801,7 +2835,7 @@ BEGIN
             _srvid);
     END IF;
 
-    RETURN v_rowcount = 1;
+    RETURN v_deleted;
 END;
 $_$ LANGUAGE plpgsql
 SET search_path = pg_catalog; /* powa_delete_and_purge_server */


### PR DESCRIPTION
Thanks to github user jw1u1 for the report.

While at it, also fix the function to return whether a remote server has been removed, as the previous code was mistakenly returning whether pg_track_settings is installed.