### PR TITLE
Fix compatibility with pg18

### DIFF
--- a/powa.c
+++ b/powa.c
@@ -83,7 +83,9 @@ static Datum powa_stat_common(PG_FUNCTION_ARGS, PowaStatKind kind);
 PG_FUNCTION_INFO_V1(powa_stat_user_functions);
 PG_FUNCTION_INFO_V1(powa_stat_all_rel);
 
-#if (PG_VERSION_NUM >= 90500)
+#if (PG_VERSION_NUM >= 180000)
+PGDLLEXPORT pg_noreturn void powa_main(Datum main_arg);
+#elif (PG_VERSION_NUM >= 90500)
 PGDLLEXPORT void powa_main(Datum main_arg) pg_attribute_noreturn();
 #else
 PGDLLEXPORT void powa_main(Datum main_arg) __attribute__((noreturn));


### PR DESCRIPTION
Upstream commit postgres/postgres@3691edf changed pg_attribute_noreturn() to pg_noreturn macro.