### PR TITLE
ci: Trigger build of powa-archivist on new release, not new tag

### DIFF
--- a/.github/workflows/powa_archivist.yml
+++ b/.github/workflows/powa_archivist.yml
@@ -1,9 +1,8 @@
 name: Trigger build and push of powa-archivist image
 
 on:
-  push:
-    tags:
-      - REL_*
+  release:
+    types: [published]
 
 env:
   TARGET_REPO: "powa-podman"


### PR DESCRIPTION
The underlying script relies on the release already existing to pick the correct version.