### PR TITLE
Fix non restrictive enough test in 01_general

### DIFF
--- a/expected/01_general.out
+++ b/expected/01_general.out
@@ -90,9 +90,9 @@ WITH ext AS (
 SELECT ext.relname, a.attname
 FROM ext
 JOIN pg_attribute a ON a.attrelid = ext.oid
-WHERE a.attname ~ '(mins|maxs)'
+WHERE a.attname ~ '^(mins|maxs)_in_range$'
 AND a.attstorage != 'm'
-ORDER BY ext.relname::text COLLATE "C", a.attname::text COLLATe "C";
+ORDER BY ext.relname::text COLLATE "C", a.attname::text COLLATE "C";
  relname | attname 
 ---------+---------
 (0 rows)

--- a/sql/01_general.sql
+++ b/sql/01_general.sql
@@ -75,9 +75,9 @@ WITH ext AS (
 SELECT ext.relname, a.attname
 FROM ext
 JOIN pg_attribute a ON a.attrelid = ext.oid
-WHERE a.attname ~ '(mins|maxs)'
+WHERE a.attname ~ '^(mins|maxs)_in_range$'
 AND a.attstorage != 'm'
-ORDER BY ext.relname::text COLLATE "C", a.attname::text COLLATe "C";
+ORDER BY ext.relname::text COLLATE "C", a.attname::text COLLATE "C";
 
 -- Aggregate data every 5 snapshots
 SET powa.coalesce = 5;


### PR DESCRIPTION
As pointed out by Marc Cousin during the review of the last commit, the checks for the STORAGE MAIN should be based on columns named either "mins_in_range" or "maxs_in_range", but it was testing columns name cnotaining "mins" or "maxs". This has been harmless for now but better to fix it in case someone uses those pattern for something else in some powa relation.