### PR TITLE
Minor stylistic changes for 4249943

### DIFF
--- a/powa--5.0.2--5.0.3.sql
+++ b/powa--5.0.2--5.0.3.sql
@@ -290,7 +290,6 @@ BEGIN
     END LOOP;
   END IF;
 END
-$$
-;
+$$; /* end of powa_fix_toast_tuple_target */
 
 SELECT @extschema@.powa_fix_toast_tuple_target();

--- a/powa--5.0.3.sql
+++ b/powa--5.0.3.sql
@@ -7432,9 +7432,7 @@ END;
 $$ LANGUAGE plpgsql
 SET search_path = pg_catalog; /* end of powa_revoke() */
 
-/* 
-   Function to set or fix the toast_tuple_target of all aggregate tables
-*/
+-- Function to set or fix the toast_tuple_target of all aggregate tables
 CREATE FUNCTION @extschema@.powa_fix_toast_tuple_target() RETURNS void
 LANGUAGE plpgsql AS
 $$
@@ -7466,13 +7464,7 @@ BEGIN
     END LOOP;
   END IF;
 END
-$$
-;
-
-
-
-
-
+$$; /* end of powa_fix_toast_tuple_target */
 
 -- mass set proper ACL IIF none of the default pseudo predefined roles exist
 DO


### PR DESCRIPTION
Remove extraneous newlines, whitespaces, use usual -- style comments and add usual "end of" function name comment.