### PR TITLE
coAdd a new powa_stat_get_activity(srvid, from, to)

### DIFF
--- a/expected/01_general.out
+++ b/expected/01_general.out
@@ -169,6 +169,12 @@ SELECT 1, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
         1 | t
 (1 row)
 
+SELECT 1, count(*) = 0 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
+ ?column? | ?column? 
+----------+----------
+        1 | t
+(1 row)
+
 SELECT "PoWA".powa_take_snapshot();
  powa_take_snapshot 
 --------------------
@@ -218,6 +224,18 @@ SELECT 2, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
 (1 row)
 
 SELECT 2, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
+ ?column? | ?column? 
+----------+----------
+        2 | t
+(1 row)
+
+SELECT 2, count(*) > 0 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
+ ?column? | ?column? 
+----------+----------
+        2 | t
+(1 row)
+
+SELECT 2, count(*) = 0 FROM "PoWA".powa_stat_get_activity(42, '-infinity', 'infinity');
  ?column? | ?column? 
 ----------+----------
         2 | t
@@ -296,6 +314,18 @@ SELECT 3, COUNT(*) > 0 FROM "PoWA".powa_statements_history;
         3 | t
 (1 row)
 
+SELECT 3, count(*) > 4 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
+ ?column? | ?column? 
+----------+----------
+        3 | t
+(1 row)
+
+SELECT 3, count(*) = 0 FROM "PoWA".powa_stat_get_activity(42, '-infinity', 'infinity');
+ ?column? | ?column? 
+----------+----------
+        3 | t
+(1 row)
+
 -- Test reset function
 SELECT * from "PoWA".powa_reset(0);
  powa_reset 
@@ -346,6 +376,12 @@ SELECT 4, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
 (1 row)
 
 SELECT 4, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
+ ?column? | ?column? 
+----------+----------
+        4 | t
+(1 row)
+
+SELECT 4, count(*) = 0 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
  ?column? | ?column? 
 ----------+----------
         4 | t

--- a/powa--5.0.3.sql
+++ b/powa--5.0.3.sql
@@ -7466,6 +7466,35 @@ BEGIN
 END
 $$; /* end of powa_fix_toast_tuple_target */
 
+CREATE FUNCTION @extschema@.powa_stat_get_activity(
+    _srvid integer,
+    _from timestamp with time zone,
+    _to timestamp with time zone
+)
+RETURNS SETOF @extschema@.powa_stat_activity_history_record
+AS
+$$
+BEGIN
+    RETURN QUERY
+        SELECT (record).*
+        FROM @extschema@.powa_stat_activity_history_current
+        WHERE srvid = _srvid
+        AND (record).ts >= _from
+        AND (record).ts <= _to
+        UNION ALL
+        SELECT (record).*
+        FROM (
+            SELECT unnest(records) AS record
+            FROM @extschema@.powa_stat_activity_history
+            WHERE srvid = _srvid
+            AND coalesce_range && tstzrange(_from, _to, '[]')
+        ) unnested
+        WHERE (unnested.record).ts >= _from
+        AND (unnested.record).ts <= _to;
+END;
+$$
+LANGUAGE plpgsql; /* end of powa_stat_get_activity */
+
 -- mass set proper ACL IIF none of the default pseudo predefined roles exist
 DO
 $$

--- a/sql/01_general.sql
+++ b/sql/01_general.sql
@@ -104,6 +104,7 @@ SELECT 1, COUNT(*) = 0 FROM "PoWA".powa_user_functions_history;
 SELECT 1, COUNT(*) = 0 FROM "PoWA".powa_all_tables_history;
 SELECT 1, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
 SELECT 1, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
+SELECT 1, count(*) = 0 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
 
 SELECT "PoWA".powa_take_snapshot();
 
@@ -115,6 +116,8 @@ SELECT 2, COUNT(*) >= 0 FROM "PoWA".powa_user_functions_history;
 SELECT 2, COUNT(*) = 0 FROM "PoWA".powa_all_tables_history;
 SELECT 2, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
 SELECT 2, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
+SELECT 2, count(*) > 0 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
+SELECT 2, count(*) = 0 FROM "PoWA".powa_stat_get_activity(42, '-infinity', 'infinity');
 
 SELECT "PoWA".powa_take_snapshot();
 SELECT "PoWA".powa_take_snapshot();
@@ -130,6 +133,8 @@ SELECT 3, COUNT(*) >= 0 FROM "PoWA".powa_user_functions_history;
 SELECT 3, COUNT(*) >= 0 FROM "PoWA".powa_all_tables_history;
 SELECT 3, COUNT(*) > 0 FROM "PoWA".powa_statements_history;
 SELECT 3, COUNT(*) > 0 FROM "PoWA".powa_statements_history;
+SELECT 3, count(*) > 4 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
+SELECT 3, count(*) = 0 FROM "PoWA".powa_stat_get_activity(42, '-infinity', 'infinity');
 
 -- Test reset function
 SELECT * from "PoWA".powa_reset(0);
@@ -142,6 +147,7 @@ SELECT 4, COUNT(*) = 0 FROM "PoWA".powa_user_functions_history;
 SELECT 4, COUNT(*) = 0 FROM "PoWA".powa_all_tables_history;
 SELECT 4, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
 SELECT 4, COUNT(*) = 0 FROM "PoWA".powa_statements_history;
+SELECT 4, count(*) = 0 FROM "PoWA".powa_stat_get_activity(0, '-infinity', 'infinity');
 
 -- Test toast_tuple_target: we shouldn't have any table belonging to powa archivist
 -- that has a column mins_in_range (it means it's a coalesced table) and isn't set


### PR DESCRIPTION
This functions retrieves all the pg_stat_activity sampled rows for the given server (either remote or local) in the given interval.

Per request from Marc Cousin.