### PR TITLE
Improve indexes on *_current tables

### DIFF
--- a/powa--5.0.3--5.1.0.sql
+++ b/powa--5.0.3--5.1.0.sql
@@ -1,6 +1,20 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION powa" to load this file. \quit
 
+-- Replace a bunch of indexes on the *_current(srvid) to include the columns
+-- used in the aggregate functions
+CREATE INDEX ON @extschema@.powa_statements_history_current(srvid, queryid, dbid);
+DROP INDEX @extschema@.powa_statements_history_current_srvid_idx;
+
+CREATE INDEX ON @extschema@.powa_kcache_metrics_current(srvid, queryid, top, dbid);
+DROP INDEX @extschema@.powa_kcache_metrics_current_srvid_idx;
+
+CREATE INDEX ON @extschema@.powa_all_indexes_history_current(srvid, dbid, relid);
+DROP INDEX @extschema@.powa_all_indexes_history_current_srvid_idx;
+
+CREATE INDEX ON @extschema@.powa_wait_sampling_history_current(srvid, queryid, dbid);
+DROP INDEX @extschema@.powa_wait_sampling_history_current_srvid_idx;
+
 ALTER TABLE @extschema@.powa_stat_activity_src_tmp
     ADD COLUMN clock_ts timestamp with time zone NOT NULL;
 

--- a/powa--5.1.0.sql
+++ b/powa--5.1.0.sql
@@ -2096,7 +2096,7 @@ CREATE TABLE @extschema@.powa_statements_history_current (
     FOREIGN KEY (srvid) REFERENCES @extschema@.powa_servers(id)
       MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX ON @extschema@.powa_statements_history_current(srvid);
+CREATE INDEX ON @extschema@.powa_statements_history_current(srvid, queryid, dbid);
 
 CREATE TABLE @extschema@.powa_statements_history_current_db (
     srvid integer NOT NULL,
@@ -2198,7 +2198,7 @@ CREATE TABLE @extschema@.powa_all_indexes_history_current (
     FOREIGN KEY (srvid) REFERENCES @extschema@.powa_servers(id)
       MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX ON @extschema@.powa_all_indexes_history_current(srvid);
+CREATE INDEX ON @extschema@.powa_all_indexes_history_current(srvid, dbid, relid);
 
 CREATE TABLE @extschema@.powa_all_indexes_history_current_db (
     srvid integer NOT NULL,
@@ -2986,7 +2986,7 @@ CREATE TABLE @extschema@.powa_kcache_metrics_current ( srvid integer NOT NULL,
     FOREIGN KEY (srvid) REFERENCES @extschema@.powa_servers(id)
       MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX ON @extschema@.powa_kcache_metrics_current(srvid);
+CREATE INDEX ON @extschema@.powa_kcache_metrics_current(srvid, queryid, top, dbid);
 
 CREATE TABLE @extschema@.powa_kcache_metrics_current_db (
     srvid integer NOT NULL,
@@ -3176,7 +3176,7 @@ CREATE TABLE @extschema@.powa_wait_sampling_history_current (
     event text NOT NULL,
     record @extschema@.powa_wait_sampling_history_record NOT NULL
 );
-CREATE INDEX ON @extschema@.powa_wait_sampling_history_current(srvid);
+CREATE INDEX ON @extschema@.powa_wait_sampling_history_current(srvid, queryid, dbid);
 
 CREATE TABLE @extschema@.powa_wait_sampling_history_current_db (
     srvid integer NOT NULL REFERENCES @extschema@.powa_servers(id)


### PR DESCRIPTION
Replace multiple indexes on the *_current(srvid) to include the columns used in the aggregate functions