### PR TITLE
Fix pg18+ pg_stat_wal compatibility

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,3 +43,4 @@ Contributors to PoWA :
   * Yuriy Vountesmery
   * Georgy Shelkovy
   * github user Nickuru
+  * Stefan Le Breton


### PR DESCRIPTION
The IO related counters have been moved to pg_stat_io.  Columns for earlier versions are kept to make the UI job easier.

Thanks to Stefan Le Breton for the report.