### PR TITLE
Fix pg_stat_recovery nullable columns

### DIFF
--- a/powa--5.1.2--5.2.0.sql
+++ b/powa--5.1.2--5.2.0.sql
@@ -1014,6 +1014,11 @@ $${
 {current_chunk_start_time, timestamp with time zone},
 {pause_state, text}
 }$$,
+$${
+last_replayed_read_lsn, last_replayed_end_lsn, last_replayed_tli,
+replay_end_lsn, replay_end_tli,
+recovery_last_xact_time, current_chunk_start_time, pause_state
+}$$,
 -- pg_stat_recovery only exists on pg19+
 _min_version => 190000
 );

--- a/powa--5.2.0.sql
+++ b/powa--5.2.0.sql
@@ -1799,6 +1799,11 @@ $${
 {current_chunk_start_time, timestamp with time zone},
 {pause_state, text}
 }$$,
+$${
+last_replayed_read_lsn, last_replayed_end_lsn, last_replayed_tli,
+replay_end_lsn, replay_end_tli,
+recovery_last_xact_time, current_chunk_start_time, pause_state
+}$$,
 -- pg_stat_recovery only exists on pg19+
 _min_version => 190000
 );


### PR DESCRIPTION
The datasource is designed to return a row even if pg_stat_recovery is empty, so all columns can be NULL even if the original view has a different behavior.